### PR TITLE
cargo fix --edition

### DIFF
--- a/bitcoin/Cargo.toml
+++ b/bitcoin/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 keywords = ["cryptocurrency", "blockchain", "bitcoin", "wallet", "ethereum"]
 readme = "README.md"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 model = { path = "../model" }

--- a/bitcoin/src/address.rs
+++ b/bitcoin/src/address.rs
@@ -1,7 +1,7 @@
 use model::{Address, crypto::{checksum, hash160}, PrivateKey};
-use network::Network;
-use private_key::BitcoinPrivateKey;
-use public_key::BitcoinPublicKey;
+use crate::network::Network;
+use crate::private_key::BitcoinPrivateKey;
+use crate::public_key::BitcoinPublicKey;
 
 use base58::ToBase58;
 use serde::Serialize;

--- a/bitcoin/src/lib.rs
+++ b/bitcoin/src/lib.rs
@@ -4,17 +4,6 @@
 
 #![forbid(unsafe_code)]
 
-extern crate base58;
-extern crate rand;
-extern crate ripemd160;
-extern crate secp256k1;
-extern crate serde;
-extern crate serde_json;
-extern crate sha2;
-
-extern crate model;
-extern crate core;
-
 pub mod address;
 pub use self::address::*;
 

--- a/bitcoin/src/private_key.rs
+++ b/bitcoin/src/private_key.rs
@@ -1,7 +1,7 @@
-use address::{BitcoinAddress, Format};
-use model::{Address, PrivateKey, PublicKey, bytes::{FromBytes, ToBytes}, crypto::checksum};
-use network::Network;
-use public_key::BitcoinPublicKey;
+use crate::address::{BitcoinAddress, Format};
+use model::{Address, PrivateKey, PublicKey, crypto::checksum};
+use crate::network::Network;
+use crate::public_key::BitcoinPublicKey;
 
 use base58::{FromBase58, ToBase58};
 use rand::Rng;
@@ -9,7 +9,7 @@ use rand::rngs::OsRng;
 use secp256k1;
 use secp256k1::Secp256k1;
 use std::{fmt, fmt::Display};
-use std::io::{Read, Result as IoResult, Write};
+//use std::io::{Write};
 use std::str::FromStr;
 
 /// Represents a Bitcoin private key

--- a/bitcoin/src/public_key.rs
+++ b/bitcoin/src/public_key.rs
@@ -1,11 +1,11 @@
-use address::{BitcoinAddress, Format};
-use model::{Address, PublicKey, bytes::{FromBytes, ToBytes}};
-use network::Network;
-use private_key::BitcoinPrivateKey;
+use crate::address::{BitcoinAddress, Format};
+use model::{Address, PublicKey};
+use crate::network::Network;
+use crate::private_key::BitcoinPrivateKey;
 
 use secp256k1;
 use std::{fmt, fmt::Display};
-use std::io::{Read, Result as IoResult, Write};
+//use std::io::{Write};
 
 /// Represents a Bitcoin public key
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 keywords = ["cryptocurrency", "blockchain", "bitcoin", "wallet", "ethereum"]
 readme = "README.md"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 bitcoin = { path = "../bitcoin" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,24 +2,6 @@
 //!
 //! A command-line tool to generate cryptocurrency wallets.
 
-extern crate arrayvec;
-extern crate base58;
-#[macro_use(value_t)]
-extern crate clap;
-extern crate digest;
-extern crate either;
-extern crate lazy_static;
-extern crate safemem;
-extern crate serde;
-extern crate serde_json;
-extern crate tiny_keccak;
-
-extern crate bitcoin;
-extern crate ethereum;
-extern crate model;
-extern crate monero;
-extern crate zcash;
-
 use bitcoin::address::Format as BitcoinFormat;
 use bitcoin::{BitcoinAddress, BitcoinPrivateKey, Network as BitcoinNetwork};
 use ethereum::{EthereumAddress, EthereumPrivateKey};
@@ -71,7 +53,7 @@ Supported Currencies: Bitcoin, Ethereum, Monero, Zcash (t-address)")
     let currency = matches.value_of("currency").unwrap();
 //    let mut compressed = matches.is_present("compressed");
     let json = matches.is_present("json");
-    let count = value_t!(matches.value_of("count"), usize).unwrap_or_else(|_e| 1);
+    let count = clap::value_t!(matches.value_of("count"), usize).unwrap_or_else(|_e| 1);
     let bitcoin_address_type = if matches.is_present("segwit") {
 //        compressed = true;
         BitcoinFormat::P2SH_P2WPKH

--- a/ethereum/Cargo.toml
+++ b/ethereum/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 keywords = ["cryptocurrency", "blockchain", "bitcoin", "wallet", "ethereum"]
 readme = "README.md"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 model = { path = "../model" }

--- a/ethereum/src/address.rs
+++ b/ethereum/src/address.rs
@@ -1,6 +1,6 @@
 use model::{Address, PrivateKey, to_hex_string};
-use private_key::EthereumPrivateKey;
-use public_key::EthereumPublicKey;
+use crate::private_key::EthereumPrivateKey;
+use crate::public_key::EthereumPublicKey;
 
 use serde::Serialize;
 use std::fmt;

--- a/ethereum/src/lib.rs
+++ b/ethereum/src/lib.rs
@@ -4,15 +4,6 @@
 
 #![forbid(unsafe_code)]
 
-extern crate hex;
-extern crate rand;
-extern crate secp256k1;
-extern crate serde;
-extern crate serde_json;
-extern crate tiny_keccak;
-
-extern crate model;
-
 pub mod address;
 pub use self::address::*;
 

--- a/ethereum/src/private_key.rs
+++ b/ethereum/src/private_key.rs
@@ -1,4 +1,4 @@
-use address::EthereumAddress;
+use crate::address::EthereumAddress;
 use model::{
     //    bytes::{FromBytes, ToBytes},
     //    crypto::checksum,
@@ -6,7 +6,7 @@ use model::{
     PrivateKey,
     PublicKey,
 };
-use public_key::EthereumPublicKey;
+use crate::public_key::EthereumPublicKey;
 
 use rand::rngs::OsRng;
 use rand::Rng;

--- a/ethereum/src/public_key.rs
+++ b/ethereum/src/public_key.rs
@@ -1,10 +1,10 @@
-use address::EthereumAddress;
+use crate::address::EthereumAddress;
 use model::{
     //    bytes::{FromBytes, ToBytes},
     Address,
     PublicKey,
 };
-use private_key::EthereumPrivateKey;
+use crate::private_key::EthereumPrivateKey;
 
 use secp256k1;
 //use std::io::{Read, Result as IoResult, Write};

--- a/ethereum/src/test.rs
+++ b/ethereum/src/test.rs
@@ -1,9 +1,9 @@
-use address::EthereumAddress;
+use crate::address::EthereumAddress;
 use model::address::Address;
 use model::private_key::PrivateKey;
 use model::public_key::PublicKey;
-use private_key::EthereumPrivateKey;
-use public_key::EthereumPublicKey;
+use crate::private_key::EthereumPrivateKey;
+use crate::public_key::EthereumPublicKey;
 
 use std::marker::PhantomData;
 

--- a/model/src/address.rs
+++ b/model/src/address.rs
@@ -1,10 +1,9 @@
-use private_key::PrivateKey;
-use public_key::PublicKey;
+use crate::private_key::PrivateKey;
+use crate::public_key::PublicKey;
 
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
-    str::FromStr,
 };
 
 /// The interface for a generic address.

--- a/model/src/private_key.rs
+++ b/model/src/private_key.rs
@@ -1,6 +1,6 @@
-use address::Address;
-use public_key::PublicKey;
-use utilities::bytes::{FromBytes, ToBytes};
+use crate::address::Address;
+use crate::public_key::PublicKey;
+
 
 use std::{fmt::{Debug, Display}, str::FromStr};
 

--- a/model/src/public_key.rs
+++ b/model/src/public_key.rs
@@ -1,11 +1,10 @@
-use address::Address;
-use private_key::PrivateKey;
-use utilities::bytes::{FromBytes, ToBytes};
+use crate::address::Address;
+use crate::private_key::PrivateKey;
+
 
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
-    str::FromStr,
 };
 
 /// The interface for a generic public key.

--- a/monero/Cargo.toml
+++ b/monero/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 keywords = ["cryptocurrency", "blockchain", "bitcoin", "wallet", "ethereum"]
 readme = "README.md"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 model = { path = "../model" }

--- a/monero/src/address.rs
+++ b/monero/src/address.rs
@@ -1,10 +1,10 @@
 use model::{Address, PrivateKey};
-use network::Network;
-use private_key::MoneroPrivateKey;
-use public_key::MoneroPublicKey;
+use crate::network::Network;
+use crate::private_key::MoneroPrivateKey;
+use crate::public_key::MoneroPublicKey;
 
 use base58::ToBase58;
-use serde::Serialize;
+
 use std::fmt;
 use std::marker::PhantomData;
 use tiny_keccak::keccak256;

--- a/monero/src/lib.rs
+++ b/monero/src/lib.rs
@@ -4,14 +4,6 @@
 
 #![forbid(unsafe_code)]
 
-extern crate base58;
-extern crate curve25519_dalek;
-extern crate rand;
-extern crate serde;
-extern crate tiny_keccak;
-
-extern crate model;
-
 pub mod address;
 pub use self::address::*;
 

--- a/monero/src/private_key.rs
+++ b/monero/src/private_key.rs
@@ -1,7 +1,7 @@
-use address::MoneroAddress;
+use crate::address::MoneroAddress;
 use model::{Address, PrivateKey, PublicKey};
-use network::Network;
-use public_key::MoneroPublicKey;
+use crate::network::Network;
+use crate::public_key::MoneroPublicKey;
 
 use curve25519_dalek::{scalar::Scalar};
 use rand::Rng;

--- a/monero/src/public_key.rs
+++ b/monero/src/public_key.rs
@@ -1,7 +1,7 @@
-use address::MoneroAddress;
+use crate::address::MoneroAddress;
 use model::{Address, PublicKey};
-use network::Network;
-use private_key::MoneroPrivateKey;
+use crate::network::Network;
+use crate::private_key::MoneroPrivateKey;
 
 use curve25519_dalek::{constants::ED25519_BASEPOINT_TABLE, scalar::Scalar};
 use std::{fmt, fmt::Display};

--- a/zcash/Cargo.toml
+++ b/zcash/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 keywords = ["cryptocurrency", "blockchain", "bitcoin", "wallet", "ethereum"]
 readme = "README.md"
 license = "GPL-3.0"
+edition = "2018"
 
 [dependencies]
 model = { path = "../model" }

--- a/zcash/src/address.rs
+++ b/zcash/src/address.rs
@@ -1,7 +1,7 @@
 use model::{Address, crypto::{checksum, hash160}, PrivateKey};
-use network::Network;
-use private_key::ZcashPrivateKey;
-use public_key::ZcashPublicKey;
+use crate::network::Network;
+use crate::private_key::ZcashPrivateKey;
+use crate::public_key::ZcashPublicKey;
 
 use base58::ToBase58;
 use serde::Serialize;
@@ -102,11 +102,11 @@ mod tests {
         });
     }
 
-    fn test_private_key_wif(private_key: &str, expected_address: &str) {
-        let private_key = ZcashPrivateKey::from_wif(private_key).unwrap();
-        let address = ZcashAddress::from_private_key(&private_key, &Format::Transparent);
-        assert_eq!(address.address, expected_address);
-    }
+//    fn test_private_key_wif(private_key: &str, expected_address: &str) {
+//        let private_key = ZcashPrivateKey::from_wif(private_key).unwrap();
+//        let address = ZcashAddress::from_private_key(&private_key, &Format::Transparent);
+//        assert_eq!(address.address, expected_address);
+//    }
 
     #[test]
     fn test_mainnet_uncompressed_private_key_to_address() {

--- a/zcash/src/lib.rs
+++ b/zcash/src/lib.rs
@@ -4,16 +4,6 @@
 
 #![forbid(unsafe_code)]
 
-extern crate base58;
-extern crate rand;
-extern crate ripemd160;
-extern crate secp256k1;
-extern crate serde;
-extern crate serde_json;
-extern crate sha2;
-
-extern crate model;
-
 pub mod address;
 pub use self::address::*;
 

--- a/zcash/src/private_key.rs
+++ b/zcash/src/private_key.rs
@@ -1,7 +1,7 @@
-use address::{ZcashAddress, Format};
+use crate::address::{ZcashAddress, Format};
 use model::{Address, PrivateKey, PublicKey, crypto::checksum};
-use network::Network;
-use public_key::ZcashPublicKey;
+use crate::network::Network;
+use crate::public_key::ZcashPublicKey;
 
 use base58::{FromBase58, ToBase58};
 use rand::Rng;

--- a/zcash/src/public_key.rs
+++ b/zcash/src/public_key.rs
@@ -1,7 +1,7 @@
-use address::{ZcashAddress, Format};
+use crate::address::{ZcashAddress, Format};
 use model::{Address, PublicKey};
-use network::Network;
-use private_key::ZcashPrivateKey;
+use crate::network::Network;
+use crate::private_key::ZcashPrivateKey;
 
 use secp256k1;
 use std::{fmt, fmt::Display};


### PR DESCRIPTION
# 2018-Specific Changes
The following is a summary of changes that only apply to code compiled with the 2018 edition compared to the 2015 edition.

1. At most once ? macro repetition operator.
2. Path changes:
    1. Paths in use declarations work the same as other paths.
    2. Paths starting with :: must be followed with an external crate.
    3. Paths in pub(in path) visibility modifiers must start with crate, self, or super.
3. Anonymous trait function parameters are not allowed.
   1. Trait function parameters may use any irrefutable pattern when the function has a body.
4. dyn is a strict keyword, in 2015 it is a weak keyword.
5. async, await, and try are reserved keywords.
6. The following lints are now deny by default:
    1. tyvar_behind_raw_pointer

## Cargo
1. If there is a target definition in a Cargo.toml manifest, it no longer automatically disables automatic discovery of other targets.
2. Target paths of the form src/{target_name}.rs are no longer inferred for targets where the path field is not set.
3. cargo install for the current directory is no longer allowed, you must specify cargo install --path . to install the current package.